### PR TITLE
Add `FileMetadata` table and `RowMetadataRegistry`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,26 @@ keywords = ["arrow", "arrow-rs", "datafusion"]
 rust-version = "1.73"
 
 [dependencies]
+arrow = "53"
+arrow-schema = "53"
+async-trait = "0.1"
+dashmap = "6"
+datafusion = "43"
+datafusion-common = "43"
+datafusion-expr = "43"
+datafusion-functions = "43"
+datafusion-functions-aggregate = "43"
+datafusion-physical-expr = "43"
+datafusion-physical-plan = "43"
+datafusion-sql = "43"
+futures = "0.3"
+itertools = "0.13"
+log = "0.4"
+object_store = "0.11"
+
+[dev-dependencies]
+anyhow = "1.0.95"
+env_logger = "0.11.6"
+tempfile = "3.14.0"
+tokio = "1.42.0"
+url = "2.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ authors = ["Matthew Cramerus <matt@polygon.io>"]
 license = "Apache-2.0"
 description = "Materialized Views & Query Rewriting in DataFusion"
 keywords = ["arrow", "arrow-rs", "datafusion"]
-rust-version = "1.73"
+rust-version = "1.80"
 
 [dependencies]
 arrow = "53"

--- a/deny.toml
+++ b/deny.toml
@@ -23,5 +23,6 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "CC0-1.0",
+  "Unicode-3.0"
 ]
 version = 2

--- a/deny.toml
+++ b/deny.toml
@@ -16,5 +16,12 @@
 # under the License.
 
 [licenses]
-allow = ["Apache-2.0"]
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "CC0-1.0",
+]
 version = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Code for incremental view maintenance.
+#![deny(missing_docs)]
+
+//! `datafusion-materialized-views` implements algorithms and functionality for materialized views in DataFusion.
+
+/// Code for incremental view maintenance against Hive-partitioned tables.
+///
+/// An example of a Hive-partitioned table is the [`ListingTable`](datafusion::datasource::listing::ListingTable).
+/// By analyzing the fragment of the materialized view query pertaining to the partition columns,
+/// we can derive a build graph that relates the files of a materialized views and the files of the tables it depends on.
 pub mod materialized;
 
 /// An implementation of Query Rewriting, an optimization that rewrites queries to make use of materialized views.
-mod rewrite;
+pub mod rewrite;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,12 @@
 /// An example of a Hive-partitioned table is the [`ListingTable`](datafusion::datasource::listing::ListingTable).
 /// By analyzing the fragment of the materialized view query pertaining to the partition columns,
 /// we can derive a build graph that relates the files of a materialized views and the files of the tables it depends on.
+///
+/// A central trait is defined for Hive-partitioned tables, [`ListingTableLike`](materialized::ListingTableLike). Note that
+/// all implementations of [`ListingTableLike`](materialized::ListingTableLike) must be registered using the
+/// [`register_listing_table`](materialized::register_listing_table) function, otherwise the tables may not be detected by
+/// the incremental view maintenance code, including components such as [`FileMetadata`](materialized::file_metadata::FileMetadata)
+/// or [`RowMetadataRegistry`](materialized::row_metadata::RowMetadataRegistry).
 pub mod materialized;
 
 /// An implementation of Query Rewriting, an optimization that rewrites queries to make use of materialized views.

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -75,6 +75,7 @@ impl ListingTableLike for ListingTable {
 
 /// A hive-partitioned table in object storage that is defined by a user-provided query.
 pub trait Materialized: ListingTableLike {
+    /// The query that defines this materialized view.
     fn query(&self) -> LogicalPlan;
 }
 

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -41,11 +41,12 @@ use datafusion::{
 use datafusion_expr::LogicalPlan;
 use itertools::Itertools;
 
-const META_COLUMN: &str = "__meta";
+/// The identifier of the column that [`RowMetadataSource`](row_metadata::RowMetadataSource) implementations should store row metadata in.
+pub const META_COLUMN: &str = "__meta";
 
 static TABLE_TYPE_REGISTRY: LazyLock<TableTypeRegistry> = LazyLock::new(TableTypeRegistry::default);
 
-/// A TableProvider whose data is backed by Hive-partitioned files in object storage.
+/// A [`TableProvider`] whose data is backed by Hive-partitioned files in object storage.
 pub trait ListingTableLike: TableProvider + 'static {
     /// Object store URLs for this table
     fn table_paths(&self) -> Vec<ListingTableUrl>;

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -83,7 +83,7 @@ pub fn register_listing_table<T: ListingTableLike>() {
 }
 
 /// Attempt to cast the given TableProvider into a [`ListingTableLike`].
-/// If the table's type has not been registered using `register_listing_table`, will return `None`.
+/// If the table's type has not been registered using [`register_listing_table`], will return `None`.
 pub fn cast_to_listing_table(table: &dyn TableProvider) -> Option<&dyn ListingTableLike> {
     TABLE_TYPE_REGISTRY.cast_to_listing_table(table)
 }

--- a/src/materialized/dependencies.rs
+++ b/src/materialized/dependencies.rs
@@ -14,9 +14,3 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
-/// Code for incremental view maintenance.
-pub mod materialized;
-
-/// An implementation of Query Rewriting, an optimization that rewrites queries to make use of materialized views.
-mod rewrite;

--- a/src/materialized/file_metadata.rs
+++ b/src/materialized/file_metadata.rs
@@ -61,6 +61,8 @@ pub struct FileMetadata {
 }
 
 impl FileMetadata {
+    /// Construct a new [`FileMetadata`] table provider that lists files for all
+    /// tables in the provided catalog list.
     pub fn new(catalog_list: Arc<dyn CatalogProviderList>) -> Self {
         Self {
             table_schema: Arc::new(Schema::new(vec![
@@ -77,6 +79,9 @@ impl FileMetadata {
         }
     }
 
+    /// Add a [`TableTypeRegistry`] to this [`FileMetadata`] table provider.
+    /// Any custom implementations of [`ListingTableLike`](super::ListingTableLike) should be registered
+    /// in the provided [`TableTypeRegistry`].
     pub fn with_table_type_registry(self, registry: Arc<TableTypeRegistry>) -> Self {
         Self { registry, ..self }
     }
@@ -208,6 +213,7 @@ impl RowMetadataSource for FileMetadata {
     }
 }
 
+/// An [`ExecutionPlan`] that scans object store metadata.
 pub struct FileMetadataExec {
     table_schema: SchemaRef,
     plan_properties: PlanProperties,

--- a/src/materialized/file_metadata.rs
+++ b/src/materialized/file_metadata.rs
@@ -1,0 +1,1163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{Int64Builder, StringBuilder, UInt64Builder};
+use arrow::record_batch::RecordBatch;
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::catalog::SchemaProvider;
+use datafusion::catalog::{CatalogProvider, Session};
+use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::datasource::{provider_as_source, TableProvider};
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::physical_expr::{create_physical_expr, EquivalenceProperties};
+use datafusion::physical_plan::expressions::{BinaryExpr, Column, Literal};
+use datafusion::physical_plan::limit::LimitStream;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PhysicalExpr,
+    PlanProperties,
+};
+use datafusion::{
+    catalog::CatalogProviderList, execution::TaskContext, physical_plan::SendableRecordBatchStream,
+};
+use datafusion_common::{DataFusionError, Result, ScalarValue, ToDFSchema};
+use datafusion_expr::{Expr, Operator, TableProviderFilterPushDown, TableType};
+use futures::stream::{self, BoxStream};
+use futures::{future, Future, FutureExt, StreamExt, TryStreamExt};
+use itertools::Itertools;
+use log::debug;
+use object_store::{ObjectMeta, ObjectStore};
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::materialized::{hive_partition::hive_partition, META_COLUMN};
+
+use super::row_metadata::RowMetadataSource;
+use super::TableTypeRegistry;
+
+/// A virtual file metadata table, inspired by the information schema column table.
+#[derive(Debug, Clone)]
+pub struct FileMetadata {
+    table_schema: SchemaRef,
+    catalog_list: Arc<dyn CatalogProviderList>,
+
+    registry: Arc<TableTypeRegistry>,
+}
+
+impl FileMetadata {
+    pub fn new(catalog_list: Arc<dyn CatalogProviderList>) -> Self {
+        Self {
+            table_schema: Arc::new(Schema::new(vec![
+                Field::new("table_catalog", DataType::Utf8, false),
+                Field::new("table_schema", DataType::Utf8, false),
+                Field::new("table_name", DataType::Utf8, false),
+                Field::new("file_path", DataType::Utf8, false),
+                Field::new("last_modified", DataType::Int64, false),
+                Field::new("size", DataType::UInt64, false),
+            ])),
+            catalog_list,
+
+            registry: Default::default(),
+        }
+    }
+
+    pub fn with_table_type_registry(self, registry: Arc<TableTypeRegistry>) -> Self {
+        Self { registry, ..self }
+    }
+}
+
+#[async_trait]
+impl TableProvider for FileMetadata {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.table_schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        session_state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let dfschema = self.table_schema.clone().to_dfschema()?;
+
+        let filters = filters
+            .iter()
+            .map(|expr| {
+                create_physical_expr(expr, &dfschema, session_state.execution_props())
+                    .map_err(|e| e.context("failed to create file metadata physical expr"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let exec = FileMetadataExec::try_new(
+            self.table_schema.clone(),
+            projection.cloned(),
+            filters,
+            limit,
+            self.catalog_list.clone(),
+            Arc::clone(&self.registry),
+        )?;
+
+        Ok(Arc::new(exec))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+}
+
+impl RowMetadataSource for FileMetadata {
+    fn name(&self) -> &str {
+        "FileMetadata"
+    }
+
+    /// Scan for partition column values using object store metadata.
+    /// This allows us to efficiently scan for distinct partition column values without
+    /// ever reading from a table directly, which is useful for low-overhead
+    /// incremental view maintenance.
+    fn row_metadata(
+        self: Arc<Self>,
+        table: datafusion_sql::ResolvedTableReference,
+        scan: &datafusion_expr::TableScan,
+    ) -> Result<datafusion_expr::LogicalPlanBuilder> {
+        use datafusion::datasource::source_as_provider;
+        use datafusion::functions::core::expr_fn::named_struct;
+        use datafusion::prelude::*;
+
+        // Check that the remaining columns in the source table scans are indeed partition columns
+        let partition_cols = self
+            .registry
+            .cast_to_listing_table(source_as_provider(&scan.source)?.as_ref())
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "Table '{}' was not registered in TableTypeRegistry",
+                    scan.table_name
+                ))
+            })?
+            .partition_columns();
+
+        for column in scan.projected_schema.columns() {
+            if !partition_cols.contains(&column.name) {
+                return Err(DataFusionError::Internal(format!("Row metadata not available on non-partition column from source table '{table}': {}", column.name)));
+            }
+        }
+
+        let fields = scan.projected_schema.fields();
+
+        let row_metadata_expr = make_array(vec![named_struct(vec![
+            lit("table_catalog"),
+            col("table_catalog"),
+            lit("table_schema"),
+            col("table_schema"),
+            lit("table_name"),
+            col("table_name"),
+            lit("source_uri"), // Map file_path to source_uri
+            col("file_path"),
+            lit("last_modified"),
+            col("last_modified"),
+        ])])
+        .alias(META_COLUMN);
+
+        datafusion_expr::LogicalPlanBuilder::scan("file_metadata", provider_as_source(self), None)?
+            .filter(
+                col("table_catalog")
+                    .eq(lit(table.catalog.as_ref()))
+                    .and(col("table_schema").eq(lit(table.schema.as_ref())))
+                    .and(col("table_name").eq(lit(table.table.as_ref()))),
+            )?
+            .project(
+                fields
+                    .iter()
+                    .map(|field| {
+                        // CAST(hive_partition(file_path, 'field_name', true) AS field_data_type) AS field_name
+                        cast(
+                            hive_partition(vec![col("file_path"), lit(field.name()), lit(true)]),
+                            field.data_type().clone(),
+                        )
+                        .alias(field.name())
+                    })
+                    .chain(Some(row_metadata_expr)),
+            )
+    }
+}
+
+pub struct FileMetadataExec {
+    table_schema: SchemaRef,
+    plan_properties: PlanProperties,
+    projection: Option<Vec<usize>>,
+    filters: Vec<Arc<dyn PhysicalExpr>>,
+    limit: Option<usize>,
+    metrics: ExecutionPlanMetricsSet,
+    catalog_list: Arc<dyn CatalogProviderList>,
+    table_type_registry: Arc<TableTypeRegistry>,
+}
+
+impl FileMetadataExec {
+    fn try_new(
+        table_schema: SchemaRef,
+        projection: Option<Vec<usize>>,
+        filters: Vec<Arc<dyn PhysicalExpr>>,
+        limit: Option<usize>,
+        catalog_list: Arc<dyn CatalogProviderList>,
+        table_type_registry: Arc<TableTypeRegistry>,
+    ) -> Result<Self> {
+        let projected_schema = match projection.as_ref() {
+            Some(projection) => Arc::new(table_schema.project(projection)?),
+            None => table_schema.clone(),
+        };
+        let eq_properties = EquivalenceProperties::new(projected_schema);
+        let partitioning = Partitioning::UnknownPartitioning(1);
+        let execution_mode = ExecutionMode::Bounded;
+        let plan_properties = PlanProperties::new(eq_properties, partitioning, execution_mode);
+
+        let exec = Self {
+            table_schema,
+            plan_properties,
+            projection,
+            filters,
+            limit,
+            metrics: ExecutionPlanMetricsSet::new(),
+            catalog_list,
+            table_type_registry,
+        };
+
+        Ok(exec)
+    }
+}
+
+impl ExecutionPlan for FileMetadataExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "FileMetadataExec"
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let projection = self.projection.clone();
+        let record_batches = self.build_record_batch(context)?;
+
+        let projected_record_batches = record_batches.map(move |record_batches| {
+            let record_batches = match record_batches {
+                Ok(record_batches) => record_batches,
+                Err(err) => return vec![Err(err)],
+            };
+
+            if let Some(projection) = projection {
+                return record_batches
+                    .into_iter()
+                    .map(|record_batch| {
+                        record_batch
+                            .project(&projection)
+                            .map_err(|e| DataFusionError::ArrowError(e, None))
+                    })
+                    .collect::<Vec<_>>();
+            }
+
+            record_batches.into_iter().map(Ok).collect::<Vec<_>>()
+        });
+
+        let mut record_batch_stream: SendableRecordBatchStream =
+            Box::pin(RecordBatchStreamAdapter::new(
+                self.schema(),
+                futures::stream::once(projected_record_batches)
+                    .map(stream::iter)
+                    .flatten(),
+            ));
+
+        if let Some(limit) = self.limit {
+            let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+            let limit_stream =
+                LimitStream::new(record_batch_stream, 0, Some(limit), baseline_metrics);
+            record_batch_stream = Box::pin(limit_stream);
+        }
+
+        Ok(record_batch_stream)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+}
+
+impl FileMetadataExec {
+    fn get_column_index(&self, column_name: &str) -> Result<usize> {
+        let (index, _) = self
+            .table_schema
+            .column_with_name(column_name)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!("column '{column_name}' does not exists"))
+            })?;
+        Ok(index)
+    }
+
+    /// Get the string literal value from an 'equals' BinaryExpr with a column.
+    fn get_column_literal(column_idx: usize, filter: &Arc<dyn PhysicalExpr>) -> Option<String> {
+        let binary_expr = filter.as_any().downcast_ref::<BinaryExpr>()?;
+
+        if !matches!(binary_expr.op(), Operator::Eq) {
+            return None;
+        }
+
+        let (column, literal) = if let Some(left_column) =
+            binary_expr.left().as_any().downcast_ref::<Column>()
+        {
+            let right_literal = binary_expr.right().as_any().downcast_ref::<Literal>()?;
+            (left_column, right_literal)
+        } else if let Some(right_column) = binary_expr.right().as_any().downcast_ref::<Column>() {
+            let left_literal = binary_expr.left().as_any().downcast_ref::<Literal>()?;
+            (right_column, left_literal)
+        } else {
+            return None;
+        };
+
+        if column.index() != column_idx {
+            return None;
+        }
+
+        match literal.value() {
+            ScalarValue::Utf8(str) => str.clone(),
+            ScalarValue::LargeUtf8(str) => str.clone(),
+            _ => None,
+        }
+    }
+
+    /// Builds a RecordBatch containing file metadata that satisfies the provided filters.
+    fn build_record_batch(
+        &self,
+        context: Arc<TaskContext>,
+    ) -> Result<impl Future<Output = Result<Vec<RecordBatch>>>> {
+        let catalog_column = self.get_column_index("table_catalog")?;
+        let schema_column = self.get_column_index("table_schema")?;
+        let table_column = self.get_column_index("table_name")?;
+
+        let catalog_name = self
+            .filters
+            .iter()
+            .filter_map(|filter| Self::get_column_literal(catalog_column, filter))
+            .next();
+
+        let schema_name = self
+            .filters
+            .iter()
+            .filter_map(|filter| Self::get_column_literal(schema_column, filter))
+            .next();
+
+        let table_name = self
+            .filters
+            .iter()
+            .filter_map(|filter| Self::get_column_literal(table_column, filter))
+            .next();
+
+        let table_schema = self.table_schema.clone();
+        let catalog_list = self.catalog_list.clone();
+        let table_type_registry = Arc::clone(&self.table_type_registry);
+
+        let record_batch = async move {
+            // If we cannot determine the catalog, build from the entire catalog list.
+            let catalog_name = match catalog_name {
+                Some(catalog_name) => catalog_name,
+                None => {
+                    debug!("No catalog filter exists, returning entire catalog list.");
+                    return FileMetadataBuilder::build_from_catalog_list(
+                        catalog_list,
+                        table_schema,
+                        context,
+                        table_type_registry,
+                    )
+                    .await;
+                }
+            };
+
+            // If the specified catalog doesn't exist, return an empty result;
+            let catalog_provider = match catalog_list.catalog(&catalog_name) {
+                Some(catalog_provider) => catalog_provider,
+                None => {
+                    debug!("No catalog named '{catalog_name}' exists, returning an empty result.");
+                    return Ok(vec![]);
+                }
+            };
+
+            // If we cannot determine the schema, build from the catalog.
+            let schema_name = match schema_name {
+                Some(schema_name) => schema_name,
+                None => {
+                    debug!("No schema filter exists, returning catalog '{catalog_name}'.");
+                    return FileMetadataBuilder::build_from_catalog(
+                        &catalog_name,
+                        catalog_provider,
+                        table_schema,
+                        context,
+                        table_type_registry,
+                    )
+                    .await;
+                }
+            };
+
+            // If the specified schema doesn't exist, return an empty result.
+            let schema_provider = match catalog_provider.schema(&schema_name) {
+                Some(schema_provider) => schema_provider,
+                None => {
+                    debug!("No schema named '{catalog_name}.{schema_name}' exists, returning an empty result.");
+                    return Ok(vec![]);
+                }
+            };
+
+            // If we cannot determine a table , build from the schema.
+            let table_name = match table_name {
+                Some(table_name) => table_name,
+                None => {
+                    debug!(
+                        "No table filter exists, returning schema '{catalog_name}.{schema_name}'."
+                    );
+                    return FileMetadataBuilder::build_from_schema(
+                        &catalog_name,
+                        &schema_name,
+                        schema_provider,
+                        table_schema,
+                        context,
+                        table_type_registry,
+                    )
+                    .await;
+                }
+            };
+
+            // If the specified table doesn't exist, return an empty result;
+            let table_provider = match schema_provider.table(&table_name).await? {
+                Some(table_provider) => table_provider,
+                None => {
+                    debug!("No table named '{catalog_name}.{schema_name}.{table_name}' exists, returning an empty result.");
+                    return Ok(vec![]);
+                }
+            };
+
+            debug!("Returning table '{catalog_name}.{schema_name}.{table_name}'.");
+
+            let record_batch = FileMetadataBuilder::build_from_table(
+                &catalog_name,
+                &schema_name,
+                &table_name,
+                table_provider,
+                table_schema,
+                context,
+                table_type_registry,
+            )
+            .await?;
+
+            Ok(record_batch.into_iter().collect_vec())
+        };
+
+        Ok(record_batch)
+    }
+}
+
+impl std::fmt::Debug for FileMetadataExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileMetadataExec")
+            .field("plan_properties", &self.plan_properties)
+            .field("filters", &self.filters)
+            .field("limit", &self.limit)
+            .finish()
+    }
+}
+
+impl DisplayAs for FileMetadataExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "FileMetadataExec: ")?;
+
+        write!(f, "filters=[")?;
+        let mut filters = self.filters.iter().peekable();
+        while let Some(filter) = filters.next() {
+            std::fmt::Display::fmt(filter, f)?;
+            if filters.peek().is_some() {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, "]")?;
+
+        if let Some(limit) = &self.limit {
+            write!(f, ", limit={limit}")?;
+        }
+
+        Ok(())
+    }
+}
+
+struct FileMetadataBuilder {
+    schema: SchemaRef,
+    catalog_names: StringBuilder,
+    schema_names: StringBuilder,
+    table_names: StringBuilder,
+    file_paths: StringBuilder,
+    last_modified: Int64Builder,
+    size: UInt64Builder,
+}
+
+impl FileMetadataBuilder {
+    fn new(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            file_paths: StringBuilder::new(),
+            last_modified: Int64Builder::new(),
+            size: UInt64Builder::new(),
+        }
+    }
+
+    async fn build_from_catalog_list(
+        catalog_list: Arc<dyn CatalogProviderList>,
+        schema: SchemaRef,
+        context: Arc<TaskContext>,
+        table_type_registry: Arc<TableTypeRegistry>,
+    ) -> Result<Vec<RecordBatch>> {
+        let mut tasks = vec![];
+
+        for catalog_name in catalog_list.catalog_names() {
+            let catalog_provider = match catalog_list.catalog(&catalog_name) {
+                Some(catalog_provider) => catalog_provider,
+                None => continue,
+            };
+            let schema = schema.clone();
+            let context = context.clone();
+            let table_type_registry = Arc::clone(&table_type_registry);
+
+            tasks.push(async move {
+                Self::build_from_catalog(
+                    &catalog_name,
+                    catalog_provider,
+                    schema,
+                    context,
+                    table_type_registry,
+                )
+                .await
+            });
+        }
+
+        let results = future::join_all(tasks).await;
+
+        let record_batches = results
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        Ok(record_batches)
+    }
+
+    async fn build_from_catalog(
+        catalog_name: &str,
+        catalog_provider: Arc<dyn CatalogProvider>,
+        schema: SchemaRef,
+        context: Arc<TaskContext>,
+        table_type_registry: Arc<TableTypeRegistry>,
+    ) -> Result<Vec<RecordBatch>> {
+        let mut tasks = vec![];
+
+        for schema_name in catalog_provider.schema_names() {
+            let schema_provider = match catalog_provider.schema(&schema_name) {
+                Some(schema_provider) => schema_provider,
+                None => continue,
+            };
+            let schema = schema.clone();
+            let context = context.clone();
+            let table_type_registry = Arc::clone(&table_type_registry);
+
+            tasks.push(async move {
+                Self::build_from_schema(
+                    catalog_name,
+                    &schema_name,
+                    schema_provider,
+                    schema,
+                    context,
+                    table_type_registry,
+                )
+                .await
+            });
+        }
+
+        let results = future::join_all(tasks).await;
+
+        let record_batches = results
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        Ok(record_batches)
+    }
+
+    async fn build_from_schema(
+        catalog_name: &str,
+        schema_name: &str,
+        schema_provider: Arc<dyn SchemaProvider>,
+        schema: SchemaRef,
+        context: Arc<TaskContext>,
+        table_type_registry: Arc<TableTypeRegistry>,
+    ) -> Result<Vec<RecordBatch>> {
+        let mut tasks = vec![];
+
+        for table_name in schema_provider.table_names() {
+            let table_provider = match schema_provider.table(&table_name).await? {
+                Some(table_provider) => table_provider,
+                None => continue,
+            };
+            let schema = schema.clone();
+            let context = context.clone();
+            let table_type_registry = Arc::clone(&table_type_registry);
+
+            tasks.push(async move {
+                Self::build_from_table(
+                    catalog_name,
+                    schema_name,
+                    &table_name,
+                    table_provider,
+                    schema,
+                    context,
+                    table_type_registry,
+                )
+                .await
+            })
+        }
+
+        let results = future::join_all(tasks).await;
+        let record_batches = results
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        Ok(record_batches)
+    }
+
+    async fn build_from_table(
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        table_provider: Arc<dyn TableProvider>,
+        schema: SchemaRef,
+        context: Arc<TaskContext>,
+        table_type_registry: Arc<TableTypeRegistry>,
+    ) -> Result<Option<RecordBatch>> {
+        let mut builder = Self::new(schema.clone());
+
+        let listing_table_like =
+            match table_type_registry.cast_to_listing_table(table_provider.as_ref()) {
+                None => return Ok(None),
+                Some(t) => t,
+            };
+
+        let table_paths = listing_table_like.table_paths();
+        let file_extension = listing_table_like.file_ext();
+
+        for table_path in table_paths {
+            builder
+                .read_table_files(
+                    catalog_name,
+                    schema_name,
+                    table_name,
+                    &table_path,
+                    &file_extension,
+                    &context,
+                )
+                .await?;
+        }
+
+        builder.finish().map(Some)
+    }
+
+    async fn read_table_files(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        table_path: &ListingTableUrl,
+        file_ext: &str,
+        context: &TaskContext,
+    ) -> Result<()> {
+        let store_url = table_path.object_store();
+        let store = context.runtime_env().object_store(table_path)?;
+
+        let mut file_stream = list_all_files(
+            store.as_ref(),
+            table_path,
+            file_ext,
+            context
+                .session_config()
+                .options()
+                .execution
+                .listing_table_ignore_subdirectory,
+        )
+        .await;
+
+        while let Some(file_meta) = file_stream.try_next().await? {
+            self.append(
+                catalog_name,
+                schema_name,
+                table_name,
+                &store_url,
+                &file_meta,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn append(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        store_url: &ObjectStoreUrl,
+        meta: &ObjectMeta,
+    ) {
+        self.catalog_names.append_value(catalog_name);
+        self.schema_names.append_value(schema_name);
+        self.table_names.append_value(table_name);
+        self.file_paths
+            .append_value(format!("{store_url}{}", meta.location));
+        self.last_modified
+            .append_option(meta.last_modified.timestamp_nanos_opt());
+        self.size.append_value(meta.size as u64); // this is not lossy assuming we're on a 64-bit platform
+    }
+
+    fn finish(mut self) -> Result<RecordBatch> {
+        RecordBatch::try_new(
+            self.schema,
+            vec![
+                Arc::new(self.catalog_names.finish()),
+                Arc::new(self.schema_names.finish()),
+                Arc::new(self.table_names.finish()),
+                Arc::new(self.file_paths.finish()),
+                Arc::new(self.last_modified.finish()),
+                Arc::new(self.size.finish()),
+            ],
+        )
+        .map_err(From::from)
+    }
+}
+
+// Mostly copied from ListingTableUrl::list_all_files, which is private to that crate
+// Modified to handle empty tables
+async fn list_all_files<'a>(
+    store: &'a dyn ObjectStore,
+    url: &'a ListingTableUrl,
+    file_extension: &'a str,
+    ignore_subdirectory: bool,
+) -> BoxStream<'a, Result<ObjectMeta>> {
+    // Check if the directory exists yet
+    if let Err(object_store::Error::NotFound { path, .. }) =
+        store.list_with_delimiter(Some(url.prefix())).await
+    {
+        debug!(
+                "attempted to list empty table at {path} during file_metadata listing, returning empty list"
+            );
+        return Box::pin(stream::empty());
+    }
+
+    let is_dir = url.as_str().ends_with('/');
+    let list = match is_dir {
+        true => store.list(Some(url.prefix())),
+        false => futures::stream::once(store.head(url.prefix())).boxed(),
+    };
+
+    list.map_err(Into::into)
+        .try_filter(move |meta| {
+            let path = &meta.location;
+            let extension_match = path.as_ref().ends_with(file_extension);
+            let glob_match = url.contains(path, ignore_subdirectory);
+            futures::future::ready(extension_match && glob_match)
+        })
+        .boxed()
+}
+
+#[cfg(test)]
+mod test {
+    use std::{ops::Deref, sync::Arc};
+
+    use anyhow::{Context, Result};
+    use datafusion::{
+        assert_batches_sorted_eq,
+        catalog_common::{MemoryCatalogProvider, MemorySchemaProvider},
+        execution::{
+            object_store::{DefaultObjectStoreRegistry, ObjectStoreRegistry},
+            runtime_env::RuntimeEnvBuilder,
+        },
+        prelude::{SessionConfig, SessionContext},
+    };
+    use object_store::local::LocalFileSystem;
+    use tempfile::TempDir;
+    use url::Url;
+
+    use super::FileMetadata;
+
+    struct TestContext {
+        _dir: TempDir,
+        ctx: SessionContext,
+    }
+
+    impl Deref for TestContext {
+        type Target = SessionContext;
+
+        fn deref(&self) -> &Self::Target {
+            &self.ctx
+        }
+    }
+
+    async fn setup() -> Result<TestContext> {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let dir = TempDir::new().context("create tempdir")?;
+        let store = LocalFileSystem::new_with_prefix(&dir)
+            .map(Arc::new)
+            .context("create local file system object store")?;
+
+        let registry = Arc::new(DefaultObjectStoreRegistry::new());
+        registry
+            .register_store(&Url::parse("file://").unwrap(), store)
+            .context("register file system store")
+            .expect("should replace existing object store at file://");
+
+        let ctx = SessionContext::new_with_config_rt(
+            SessionConfig::new(),
+            RuntimeEnvBuilder::new()
+                .with_object_store_registry(registry)
+                .build_arc()
+                .context("create RuntimeEnv")?,
+        );
+
+        ctx.catalog("datafusion")
+            .context("get default catalog")?
+            .register_schema("private", Arc::<MemorySchemaProvider>::default())
+            .context("register datafusion.private schema")?;
+
+        ctx.register_catalog("datafusion_mv", Arc::<MemoryCatalogProvider>::default());
+
+        ctx.catalog("datafusion_mv")
+            .context("get datafusion_mv catalog")?
+            .register_schema("public", Arc::<MemorySchemaProvider>::default())
+            .context("register datafusion_mv.public schema")?;
+
+        ctx.sql(
+            "
+            CREATE EXTERNAL TABLE t1 (num INTEGER, year TEXT)
+            STORED AS CSV
+            PARTITIONED BY (year)
+            LOCATION 'file:///t1/'
+        ",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        ctx.sql(
+            "INSERT INTO t1 VALUES 
+            (1, '2021'),
+            (2, '2022'),
+            (3, '2023'),
+            (4, '2024')
+        ",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        ctx.sql(
+            "
+            CREATE EXTERNAL TABLE private.t1 (num INTEGER, year TEXT, month TEXT)
+            STORED AS CSV
+            PARTITIONED BY (year, month)
+            LOCATION 'file:///private/t1/'
+        ",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        ctx.sql(
+            "INSERT INTO private.t1 VALUES 
+            (1, '2021', '01'),
+            (2, '2022', '02'),
+            (3, '2023', '03'),
+            (4, '2024', '04')
+        ",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        ctx.sql(
+            "
+            CREATE EXTERNAL TABLE datafusion_mv.public.t3 (num INTEGER, date DATE)
+            STORED AS CSV
+            PARTITIONED BY (date)
+            LOCATION 'file:///datafusion_mv/public/t3/'
+        ",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        ctx.sql(
+            "INSERT INTO datafusion_mv.public.t3 VALUES 
+            (1, '2021-01-01'),
+            (2, '2022-02-02'),
+            (3, '2023-03-03'),
+            (4, '2024-04-04')
+        ",
+        )
+        .await?
+        .collect()
+        .await?;
+
+        ctx.register_table(
+            "file_metadata",
+            Arc::new(FileMetadata::new(Arc::clone(ctx.state().catalog_list()))),
+        )
+        .context("register file metadata table")?;
+
+        ctx.sql(
+            // Remove timestamps and trim (randomly generated) file names since they're not stable in tests
+            "CREATE VIEW file_metadata_test_view AS SELECT
+                * EXCLUDE(file_path, last_modified), 
+                regexp_replace(file_path, '/[^/]*$', '/') AS file_path 
+            FROM file_metadata",
+        )
+        .await
+        .context("create file metadata test view")?;
+
+        Ok(TestContext { _dir: dir, ctx })
+    }
+
+    #[tokio::test]
+    async fn test_list_all_files() -> Result<()> {
+        let ctx = setup().await.context("setup")?;
+
+        let results = ctx
+            .sql("SELECT * FROM file_metadata_test_view")
+            .await?
+            .collect()
+            .await?;
+
+        assert_batches_sorted_eq!(&[
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+            "| table_catalog | table_schema | table_name | size | file_path                                        |",
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2021/month=01/           |",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2022/month=02/           |",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2023/month=03/           |",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2024/month=04/           |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2021/                            |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2022/                            |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2023/                            |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2024/                            |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2021-01-01/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2022-02-02/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2023-03-03/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2024-04-04/ |",
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+        ], &results);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_catalog() -> Result<()> {
+        let ctx = setup().await.context("setup")?;
+
+        let results = ctx
+            .sql(
+                "SELECT * FROM file_metadata_test_view
+                WHERE table_catalog = 'datafusion_mv'",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        assert_batches_sorted_eq!(&[
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+            "| table_catalog | table_schema | table_name | size | file_path                                        |",
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2021-01-01/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2022-02-02/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2023-03-03/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2024-04-04/ |",
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+        ], &results);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_catalog_and_schema() -> Result<()> {
+        let ctx = setup().await.context("setup")?;
+
+        let results = ctx
+            .sql(
+                "SELECT * FROM file_metadata_test_view
+                WHERE table_catalog = 'datafusion' AND table_schema = 'private'",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        assert_batches_sorted_eq!(&[
+            "+---------------+--------------+------------+------+----------------------------------------+",
+            "| table_catalog | table_schema | table_name | size | file_path                              |",
+            "+---------------+--------------+------------+------+----------------------------------------+",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2021/month=01/ |",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2022/month=02/ |",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2023/month=03/ |",
+            "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2024/month=04/ |",
+            "+---------------+--------------+------------+------+----------------------------------------+",
+        ], &results);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_schema_only() -> Result<()> {
+        let ctx = setup().await.context("setup")?;
+
+        let results = ctx
+            .sql(
+                "SELECT * FROM file_metadata_test_view
+                WHERE table_schema = 'public'",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        assert_batches_sorted_eq!(&[
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+            "| table_catalog | table_schema | table_name | size | file_path                                        |",
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2021/                            |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2022/                            |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2023/                            |",
+            "| datafusion    | public       | t1         | 6    | file:///t1/year=2024/                            |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2021-01-01/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2022-02-02/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2023-03-03/ |",
+            "| datafusion_mv | public       | t3         | 6    | file:///datafusion_mv/public/t3/date=2024-04-04/ |",
+            "+---------------+--------------+------------+------+--------------------------------------------------+",
+        ], &results);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_catalog_schema_and_table() -> Result<()> {
+        let ctx = setup().await.context("setup")?;
+
+        let results = ctx
+            .sql(
+                "SELECT * FROM file_metadata_test_view
+                WHERE table_catalog = 'datafusion' AND table_schema = 'public' AND table_name = 't1'",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        assert_batches_sorted_eq!(
+            &[
+                "+---------------+--------------+------------+------+-----------------------+",
+                "| table_catalog | table_schema | table_name | size | file_path             |",
+                "+---------------+--------------+------------+------+-----------------------+",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2021/ |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2022/ |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2023/ |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2024/ |",
+                "+---------------+--------------+------------+------+-----------------------+",
+            ],
+            &results
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_table_only() -> Result<()> {
+        let ctx = setup().await.context("setup")?;
+
+        let results = ctx
+            .sql(
+                "SELECT * FROM file_metadata_test_view
+                WHERE table_name = 't1'",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        assert_batches_sorted_eq!(
+            &[
+                "+---------------+--------------+------------+------+----------------------------------------+",
+                "| table_catalog | table_schema | table_name | size | file_path                              |",
+                "+---------------+--------------+------------+------+----------------------------------------+",
+                "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2021/month=01/ |",
+                "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2022/month=02/ |",
+                "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2023/month=03/ |",
+                "| datafusion    | private      | t1         | 6    | file:///private/t1/year=2024/month=04/ |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2021/                  |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2022/                  |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2023/                  |",
+                "| datafusion    | public       | t1         | 6    | file:///t1/year=2024/                  |",
+                "+---------------+--------------+------------+------+----------------------------------------+",
+            ],
+            &results
+        );
+
+        Ok(())
+    }
+}

--- a/src/materialized/hive_partition.rs
+++ b/src/materialized/hive_partition.rs
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, StringArray, StringBuilder};
+use arrow_schema::DataType;
+
+use datafusion_common::{DataFusionError, Result, ScalarValue};
+use datafusion_expr::{
+    expr::ScalarFunction, ColumnarValue, Expr, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
+};
+
+pub static HIVE_PARTITION_UDF_NAME: &str = "hive_partition";
+
+/// A DataFusion UDF with the following signature:
+///
+/// ```ignore
+///     hive_partition(file_path: Utf8, partition_column: Utf8, null_if_missing: bool = false) -> Utf8
+/// ```
+///
+/// that extracts the partition column from a path, assuming the file path follows the Hive partitioning scheme.
+/// Partition values are returned as strings;
+/// use the ARROW_CAST function to coerce the partition values into the correct data type.
+///
+/// # `null_if_missing`
+///
+/// By default, `hive_partition` throws an error if the named partition column is absent.
+/// One can instead return null in such cases by passing a third argument:
+/// ```sql
+///     hive_partition(<path>, <column_name>, true)
+/// ```
+/// which will not throw an error if <column_name> is absent from <path>.
+///
+/// # Examples
+///
+/// ```sql
+/// SELECT
+///     column_name,
+///     hive_partition(
+///         's3://atlas/sip/trades/year=2006/month=01/day=02/trades-2006-01-02.parquet',
+///         column_name
+///     ) AS partition_value
+/// FROM (VALUES ('year'), ('month'), ('day')) AS partition_columns (column_name);
+///
+/// // +-------------+-----------------+
+/// // | column_name | partition_value |
+/// // +-------------+-----------------+
+/// // | year        | 2006            |
+/// // | month       | 01              |
+/// // | day         | 02              |
+/// // +-------------+-----------------+
+/// ```
+pub fn hive_partition_udf() -> ScalarUDF {
+    let signature = Signature::one_of(
+        vec![
+            TypeSignature::Uniform(2, vec![DataType::Utf8]),
+            TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Boolean]),
+        ],
+        Volatility::Immutable,
+    );
+
+    let udf_impl = HivePartitionUdf { signature };
+    ScalarUDF::new_from_impl(udf_impl)
+}
+
+#[derive(Debug)]
+struct HivePartitionUdf {
+    pub signature: Signature,
+}
+
+impl ScalarUDFImpl for HivePartitionUdf {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        HIVE_PARTITION_UDF_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke(&self, values: &[ColumnarValue]) -> Result<ColumnarValue> {
+        let null_if_missing = values
+            .get(2)
+            .map(|val| match val {
+                ColumnarValue::Scalar(ScalarValue::Boolean(Some(b))) => Ok(*b),
+                _ => Err(DataFusionError::Execution(
+                    "expected a boolean scalar for argument #3 of 'hive_partition'".to_string(),
+                )),
+            })
+            .transpose()?
+            .unwrap_or(false);
+
+        let arrays = ColumnarValue::values_to_arrays(values)?;
+
+        let [file_paths, table_partition_columns]: [Option<&StringArray>; 2] =
+            [&arrays[0], &arrays[1]].map(|arg| arg.as_any().downcast_ref());
+
+        file_paths
+            .zip(table_partition_columns)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "Error while executing {HIVE_PARTITION_UDF_NAME}: \
+                    Type check failed"
+                ))
+            })
+            .and_then(|(file_paths, table_partition_columns)| {
+                let mut builder = StringBuilder::new();
+
+                for (file_path, table_partition_column) in
+                    file_paths.iter().zip(table_partition_columns.iter())
+                {
+                    match file_path.zip(table_partition_column) {
+                        Some((file_path, table_partition_column)) => {
+                            builder.append_option(parse_partitions_for_path(
+                                file_path,
+                                table_partition_column,
+                                null_if_missing,
+                            )?);
+                        }
+                        _ => builder.append_null(),
+                    };
+                }
+
+                Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+            })
+    }
+}
+
+pub fn hive_partition(args: Vec<Expr>) -> Expr {
+    Expr::ScalarFunction(ScalarFunction {
+        func: Arc::new(hive_partition_udf()),
+        args,
+    })
+}
+
+// Extract partition column values from a file path, erroring if any partition columns are not found.
+// Accepts a ListingTableUrl that will be trimmed from the file paths as well.
+fn parse_partitions_for_path<'a>(
+    file_path: &'a str,
+    table_partition_col: &str,
+    null_if_missing: bool,
+) -> Result<Option<&'a str>> {
+    match file_path.split('/').find_map(|part| {
+        part.split_once('=')
+            .and_then(|(name, val)| (name == table_partition_col).then_some(val))
+    }) {
+        Some(part) => Ok(Some(part)),
+        None if null_if_missing => Ok(None),
+        _ => Err(DataFusionError::Execution(format!(
+            "Error while executing {HIVE_PARTITION_UDF_NAME}: \
+                    Path '{file_path}' did not contain any values corresponding to \
+                    partition column '{table_partition_col}'"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::HIVE_PARTITION_UDF_NAME;
+
+    use datafusion::{assert_batches_sorted_eq, prelude::SessionContext};
+    use datafusion_common::Result;
+
+    struct TestCase {
+        file_path_expr: &'static str,
+        partition_columns: &'static [&'static str],
+        expected_output: &'static str,
+    }
+
+    async fn run_test(context: &SessionContext, case: TestCase) -> Result<()> {
+        let query = format!(
+            "SELECT \
+                column_name, \
+                {HIVE_PARTITION_UDF_NAME}({}, column_name) AS partition_value \
+            FROM (VALUES {}) AS partition_columns (column_name)",
+            case.file_path_expr,
+            case.partition_columns
+                .iter()
+                .map(|s| format!("('{s}')"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        let df = context.sql(dbg!(&query)).await?;
+        df.clone().show().await?;
+
+        let results = df.collect().await?;
+        assert_batches_sorted_eq!(
+            case.expected_output
+                .split_terminator('\n')
+                .filter(|s| !s.is_empty())
+                .map(str::trim)
+                .collect::<Vec<_>>(),
+            &results
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_extract_hive_partitions() {
+        let context = SessionContext::new();
+        context.register_udf(super::hive_partition_udf());
+
+        let cases = vec![TestCase {
+            file_path_expr: "'sip/trades/year=2006/month=01/day=02/trades-2006-01-02.parquet'",
+            partition_columns: &["year", "month", "day"],
+            expected_output: "
+                +-------------+-----------------+
+                | column_name | partition_value |
+                +-------------+-----------------+
+                | year        | 2006            |
+                | month       | 01              |
+                | day         | 02              |
+                +-------------+-----------------+",
+        }];
+
+        for case in cases {
+            run_test(&context, case).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_extract_hive_partitions_fails() {
+        let context = SessionContext::new();
+        context.register_udf(super::hive_partition_udf());
+
+        let cases = vec![
+            TestCase {
+                file_path_expr: "'sip/trades/year=2006/month=01/day=02/trades-2006-01-02.parquet'",
+                partition_columns: &["this-is-not-a-valid-partition-column"],
+                expected_output: "",
+            },
+            TestCase {
+                file_path_expr: "1", // numbers should fail the type check
+                partition_columns: &["year", "month", "day"],
+                expected_output: "",
+            },
+        ];
+
+        for case in cases {
+            dbg!(run_test(&context, case).await).expect_err("test should fail");
+        }
+    }
+}

--- a/src/materialized/row_metadata.rs
+++ b/src/materialized/row_metadata.rs
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use dashmap::DashMap;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_expr::{LogicalPlanBuilder, TableScan};
+use datafusion_sql::ResolvedTableReference;
+use std::sync::Arc;
+
+/// Registry that manages metadata sources for different tables.
+/// Provides a centralized way to register and retrieve metadata sources
+/// that can be used to obtain row-level metadata for tables.
+#[derive(Default)]
+pub struct RowMetadataRegistry {
+    metadata_sources: DashMap<String, Arc<dyn RowMetadataSource>>,
+}
+
+impl RowMetadataRegistry {
+    /// Registers a metadata source for a specific table.
+    /// Returns the previously registered source for this table, if any
+    pub fn register_source(
+        &self,
+        table: &ResolvedTableReference,
+        source: Arc<dyn RowMetadataSource>,
+    ) -> Option<Arc<dyn RowMetadataSource>> {
+        self.metadata_sources.insert(table.to_string(), source)
+    }
+
+    pub fn get_source(&self, table: &ResolvedTableReference) -> Result<Arc<dyn RowMetadataSource>> {
+        self.metadata_sources
+            .get(&table.to_string())
+            .map(|o| Arc::clone(o.value()))
+            .ok_or_else(|| DataFusionError::Internal(format!("No metadata source for {}", table)))
+    }
+}
+
+/// A source for "row metadata", that associates rows from a table with
+/// metadata used for incremental view maintenance.
+///
+/// Most use cases should default to using [`FileMetadata`] for their [`RowMetadataSource`],
+/// which uses object store metadata to perform incremental view maintenance on Hive-partitioned tables.
+/// However, in some use cases it is necessary to track metadata at a more granular level than Hive partitions.
+/// In such cases, users may implement a custom [`RowMetadataSource`] containing this metadata.
+///
+/// A [`RowMetadataSource`] may contain metadata for multiple tables.
+/// As such, it is the user's responsibility to register each table with the appropriate
+/// [`RowMetadataSource`] in the [`RowMetadataRegistry`].
+pub trait RowMetadataSource: Send + Sync {
+    /// The name of this row metadata source.
+    fn name(&self) -> &str;
+
+    /// Rewrite this [`TableScan`] as query against this [`RowMetadataSource`],
+    /// this time adding a new struct column, `__meta`, whose shape conforms to the following schema:
+    ///
+    /// ```json
+    /// {
+    ///     "table_catalog": "string",
+    ///     "table_schema": "string",
+    ///     "table_name": "string",
+    ///     "source_uri": "string",
+    ///     "last_modified": "timestamp",
+    /// }
+    /// ```
+    ///
+    /// The returned data should contain the original table scan, up to multiplicity.
+    /// That is, for each row in the original table scan, the [`RowMetadataSource`] should contain at least
+    /// one row (but potentially more) with the same values, plus the `__meta` column.
+    fn row_metadata(
+        self: Arc<Self>,
+        table: ResolvedTableReference,
+        scan: &TableScan,
+    ) -> Result<LogicalPlanBuilder>;
+}

--- a/src/materialized/row_metadata.rs
+++ b/src/materialized/row_metadata.rs
@@ -40,6 +40,7 @@ impl RowMetadataRegistry {
         self.metadata_sources.insert(table.to_string(), source)
     }
 
+    /// Retrieves the registered [`RowMetadataSource`] for a specific table.
     pub fn get_source(&self, table: &ResolvedTableReference) -> Result<Arc<dyn RowMetadataSource>> {
         self.metadata_sources
             .get(&table.to_string())
@@ -51,7 +52,7 @@ impl RowMetadataRegistry {
 /// A source for "row metadata", that associates rows from a table with
 /// metadata used for incremental view maintenance.
 ///
-/// Most use cases should default to using [`FileMetadata`] for their [`RowMetadataSource`],
+/// Most use cases should default to using [`FileMetadata`](super::file_metadata::FileMetadata) for their [`RowMetadataSource`],
 /// which uses object store metadata to perform incremental view maintenance on Hive-partitioned tables.
 /// However, in some use cases it is necessary to track metadata at a more granular level than Hive partitions.
 /// In such cases, users may implement a custom [`RowMetadataSource`] containing this metadata.


### PR DESCRIPTION
This PR is mostly a port of internal code from Polygon.io, with some new additions to make it generic so that users with custom `TableProvider` implementations can use it effectively. 

`FileMetadata` is a custom `TableProvider` that exposes object store metadata through SQL. It implements `RowMetadataSource`, a trait that provides metadata which will be used in incremental view maintenance (which is not included in this PR). 

In order for these components to accommodate custom table types, we have added a `ListingTableLike` trait that abstracts away the essential features of a Hive-partitioned table. Users must register their custom table types using the `register_listing_table` API if they expect this crate to detect and work properly with these tables.

This PR ended up quite a bit bigger than I expected, unfortunately. Most of the length comes from the `FileMetadata` table provider, which implements filter pushdown. 