### PR TITLE
stale_files + rename to mv_dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a typical pattern with DataFusion, as files in object storage usually ar
 
 Here we walk through a hypothetical example of setting up a materialized view, to illustrate
 what this library offers. The core of the incremental view maintenance implementation is a UDTF (User-Defined Table Function), 
-called `file_dependencies`, that outputs a build graph for a materialized view. This gives users the information they need to determine
+called `mv_dependencies`, that outputs a build graph for a materialized view. This gives users the information they need to determine
 when partitions of the materialized view need to be recomputed.
 
 ```sql
@@ -39,8 +39,8 @@ CREATE MATERIALIZED VIEW m1 AS SELECT
 PARTITIONED BY (year)
 LOCATION 's3://m1/';
 
--- Show the dependency graph for m1 using the file_dependencies UDTF
-SELECT * FROM file_dependencies('m1');
+-- Show the dependency graph for m1 using the mv_dependencies UDTF
+SELECT * FROM mv_dependencies('m1');
 
 +--------------------+----------------------+---------------------+-------------------+--------------------------------------+----------------------+
 | target             | source_table_catalog | source_table_schema | source_table_name | source_uri                           | source_last_modified |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 /// otherwise the tables may not be detected by the incremental view maintenance code,
 /// including components such as [`FileMetadata`](materialized::file_metadata::FileMetadata),
 /// [`RowMetadataRegistry`](materialized::row_metadata::RowMetadataRegistry), or the
-/// [`file_dependencies`](materialized::dependencies::file_dependencies) UDTF.
+/// [`mv_dependencies`](materialized::dependencies::mv_dependencies) UDTF.
 ///
 /// By default, `ListingTableLike` is implemented for [`ListingTable`](datafusion::datasource::listing::ListingTable),
 pub mod materialized;


### PR DESCRIPTION
* Add new `stale_files` UDTF that helps track when files are old or invalidated.
* Rename `file_dependencies` to `mv_dependencies` since the `RowMetadataSource` abstraction means that a "source" does not necessarily correspond to files. 