### PR TITLE
add changelog manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/datafusion-contrib/datafusion-materialized-views/releases/tag/v0.1.0) - 2025-01-03
+
+### Other
+- some api improvements + remove manual changelog ([#12](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/12)) (by @suremarc) - #12
+- Integration test ([#10](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/10)) (by @suremarc) - #10
+- setup changelog ([#9](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/9)) (by @suremarc) - #9
+- Release plz ([#7](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/7)) (by @suremarc) - #7
+- stale_files + rename to mv_dependencies ([#6](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/6)) (by @suremarc) - #6
+- Incremental view maintenance ([#3](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/3)) (by @suremarc) - #3
+- Add `FileMetadata` table and `RowMetadataRegistry` ([#2](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/2)) (by @suremarc) - #2
+- Setup cargo + CI ([#1](https://github.com/datafusion-contrib/datafusion-materialized-views/pull/1)) (by @suremarc)
+- Initial commit (by @matthewmturner)
+
+### Contributors
+
+* @suremarc
+* @matthewmturner


### PR DESCRIPTION
~~GH Actions seems to have lost track of the `release-plz` PR, so we're adding the autogenerated changelog manually~~

Turns out it was a bug in the CI pipeline, but now that we (accidentally) released v0.1.0, we still need to add the changelog retroactively. 