### PR TITLE
feat: add constructor for RowMetadataRegistry from FileMetadata

### DIFF
--- a/src/materialized/row_metadata.rs
+++ b/src/materialized/row_metadata.rs
@@ -52,6 +52,15 @@ impl std::fmt::Debug for RowMetadataRegistry {
 }
 
 impl RowMetadataRegistry {
+    /// Initializes this `RowMetadataRegistry` with a [`FileMetadata`] as the default
+    /// row metadata source.
+    ///
+    /// This should be the typical entrypoint for most usecases.
+    pub fn new(file_metadata: Arc<FileMetadata>) -> Self {
+        Self::new_with_default_source(Arc::new(ObjectStoreRowMetadataSource::new(file_metadata))
+            as Arc<dyn RowMetadataSource + 'static>)
+    }
+
     /// Initializes this `RowMetadataRegistry` with a default [`RowMetadataSource`]
     /// to be used if a table has not been explicitly registered with a specific source.
     ///

--- a/tests/materialized_listing_table.rs
+++ b/tests/materialized_listing_table.rs
@@ -41,7 +41,7 @@ use datafusion_materialized_views::materialized::{
     dependencies::{mv_dependencies, stale_files},
     file_metadata::FileMetadata,
     register_materialized,
-    row_metadata::{ObjectStoreRowMetadataSource, RowMetadataRegistry},
+    row_metadata::RowMetadataRegistry,
     ListingTableLike, Materialized,
 };
 use datafusion_physical_plan::{collect, ExecutionPlan};
@@ -147,10 +147,7 @@ async fn setup() -> Result<TestContext> {
     // They have `FileMetadata` and `RowMetadataRegistry` as dependencies.
 
     let file_metadata = Arc::new(FileMetadata::new(Arc::clone(ctx.state().catalog_list())));
-
-    let row_metadata_registry = Arc::new(RowMetadataRegistry::new_with_default_source(Arc::new(
-        ObjectStoreRowMetadataSource::new(Arc::clone(&file_metadata)),
-    )));
+    let row_metadata_registry = Arc::new(RowMetadataRegistry::new(Arc::clone(&file_metadata)));
 
     ctx.register_udtf(
         "mv_dependencies",


### PR DESCRIPTION
Made a default constructor for `RowMetadataRegistry` that accepts a `FileMetadata`, to emphasize the typical path. 