### PR TITLE
Compute best mv in `PruneCandidates` optimizer

### DIFF
--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -43,6 +43,16 @@ use super::QueryRewriteOptions;
 /// A cost function. Used to evaluate the best physical plan among multiple equivalent choices.
 pub type CostFn = Arc<dyn Fn(&dyn ExecutionPlan) -> f64 + Send + Sync>;
 
+/// Wrapper for CostFn that implements Debug.
+#[derive(Clone)]
+pub struct CostFnWrapper(pub CostFn);
+
+impl std::fmt::Debug for CostFnWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CostFnWrapper")
+    }
+}
+
 /// A logical optimizer that generates candidate logical plans in the form of [`OneOf`] nodes.
 #[derive(Debug)]
 pub struct ViewMatcher {
@@ -210,21 +220,11 @@ fn locate_single_table_scan(node: &LogicalPlan) -> Result<Option<TableReference>
     Ok(table_reference)
 }
 
-/// [`ExtensionPlanner`]` that chooses the best plan from a `OneOf` node.
-pub struct ViewExploitationPlanner {
-    cost: CostFn,
-}
-
-impl ViewExploitationPlanner {
-    /// Initialize this ViewExploitationPlanner with a given cost function.
-    pub fn new(cost: CostFn) -> Self {
-        Self { cost }
-    }
-}
+/// [`ExtensionPlanner`]` that converts `OneOf` logical nodes into a correspanding physical plan
+pub struct ViewExploitationPlanner;
 
 #[async_trait]
 impl ExtensionPlanner for ViewExploitationPlanner {
-    /// Choose the best candidate and use it for the physical plan.
     async fn plan_extension(
         &self,
         _planner: &dyn PhysicalPlanner,
@@ -260,7 +260,6 @@ impl ExtensionPlanner for ViewExploitationPlanner {
         Ok(Some(Arc::new(OneOfExec::try_new(
             physical_inputs.to_vec(),
             None,
-            Arc::clone(&self.cost),
         )?)))
     }
 }
@@ -317,10 +316,6 @@ pub struct OneOfExec {
     // This will inform DataFusion to add sorts to children,
     // which will improve cost estimation of candidates
     required_input_ordering: Option<LexRequirement>,
-    // Index of the candidate with the best cost
-    best: usize,
-    // Cost function to use in optimization
-    cost: CostFn,
 }
 
 impl std::fmt::Debug for OneOfExec {
@@ -328,7 +323,6 @@ impl std::fmt::Debug for OneOfExec {
         f.debug_struct("OneOfExec")
             .field("candidates", &self.candidates)
             .field("required_input_ordering", &self.required_input_ordering)
-            .field("best", &self.best)
             .finish_non_exhaustive()
     }
 }
@@ -338,30 +332,17 @@ impl OneOfExec {
     pub fn try_new(
         candidates: Vec<Arc<dyn ExecutionPlan>>,
         required_input_ordering: Option<LexRequirement>,
-        cost: CostFn,
     ) -> Result<Self> {
         if candidates.is_empty() {
             return Err(DataFusionError::Plan(
                 "can't create OneOfExec with empty children".to_string(),
             ));
         }
-        let best = candidates
-            .iter()
-            .position_min_by_key(|candidate| OrderedFloat(cost(candidate.as_ref())))
-            .unwrap();
 
         Ok(Self {
             candidates,
             required_input_ordering,
-            best,
-            cost,
         })
-    }
-
-    /// Return the best of this `OneOfExec`'s children, using the cost function provided to
-    /// this plan at initialization timee
-    pub fn best(&self) -> Arc<dyn ExecutionPlan> {
-        Arc::clone(&self.candidates[self.best])
     }
 
     /// Modify this plan's required input ordering.
@@ -384,7 +365,7 @@ impl ExecutionPlan for OneOfExec {
     }
 
     fn properties(&self) -> &PlanProperties {
-        self.candidates[self.best].properties()
+        self.candidates[0].properties()
     }
 
     fn required_input_ordering(&self) -> Vec<Option<LexRequirement>> {
@@ -414,7 +395,6 @@ impl ExecutionPlan for OneOfExec {
         Ok(Arc::new(Self::try_new(
             children,
             self.required_input_ordering.clone(),
-            Arc::clone(&self.cost),
         )?))
     }
 
@@ -423,35 +403,25 @@ impl ExecutionPlan for OneOfExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        self.candidates[self.best].execute(partition, context)
-    }
-
-    fn statistics(&self) -> Result<datafusion_common::Statistics> {
-        self.candidates[self.best].partition_statistics(None)
+        // The method shouldn't be called in practice, as the execution plan will be removed by optimizer.
+        self.candidates[0].execute(partition, context)
     }
 
     fn partition_statistics(
         &self,
         partition: Option<usize>,
     ) -> Result<datafusion_common::Statistics> {
-        self.candidates[self.best].partition_statistics(partition)
+        self.candidates[0].partition_statistics(partition)
     }
 }
 
 impl DisplayAs for OneOfExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let costs = self
-            .children()
-            .iter()
-            .map(|c| (self.cost)(c.as_ref()))
-            .collect_vec();
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 write!(
                     f,
-                    "OneOfExec(best={}), costs=[{}], required_input_ordering=[{}]",
-                    self.best,
-                    costs.into_iter().join(","),
+                    "OneOfExec: required_input_ordering=[{}]",
                     format_physical_sort_requirement_list(
                         &self
                             .required_input_ordering
@@ -470,8 +440,20 @@ impl DisplayAs for OneOfExec {
 }
 
 /// Finalize selection of best candidate plan from a OneOfExec.
-#[derive(Debug, Clone, Default)]
-pub struct PruneCandidates;
+#[derive(Debug, Clone)]
+pub struct PruneCandidates {
+    /// Cost function to use in optimization
+    pub cost: CostFnWrapper,
+}
+
+impl PruneCandidates {
+    /// Create a new `PruneCandidates` optimizer rule with the given cost function.
+    pub fn new(cost: CostFn) -> Self {
+        Self {
+            cost: CostFnWrapper(cost),
+        }
+    }
+}
 
 impl PhysicalOptimizerRule for PruneCandidates {
     fn optimize(
@@ -482,8 +464,16 @@ impl PhysicalOptimizerRule for PruneCandidates {
         // Search for any OneOfExec nodes.
         plan.transform(&|plan: Arc<dyn ExecutionPlan>| {
             if let Some(one_of_exec) = plan.as_any().downcast_ref::<OneOfExec>() {
+                let candidates = one_of_exec.children();
+                let best = candidates
+                    .iter()
+                    .position_min_by_key(|candidate| {
+                        OrderedFloat((self.cost.0)(candidate.as_ref()))
+                    })
+                    .unwrap();
+
                 Ok(Transformed::new(
-                    one_of_exec.best(),
+                    Arc::clone(candidates[best]),
                     true,
                     TreeNodeRecursion::Jump,
                 ))


### PR DESCRIPTION
Before the PR, the best mv will be computed at the initialization of `OneofExec` , before the physical optimizer, it doesn’t make sense, because filter pushdown in DF48 is in a physical optimizer rule. 