### PR TITLE
Fix OneOf branch ordering: keep base at branches[0] and make candidate order deterministic

### DIFF
--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -217,8 +217,10 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             Ok(form) => form,
         };
 
-        // Generate candidate substitutions
-        let candidates = self
+        // Generate candidate substitutions. `mv_plans` is a HashMap, so sort
+        // by table reference to keep the branch order deterministic across
+        // runs and processes.
+        let mut candidates = self
             .parent
             .mv_plans
             .iter()
@@ -233,6 +235,7 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                             provider_as_source(Arc::clone(table)),
                         )
                         .transpose()
+                        .map(|res| res.map(|plan| (table_ref.clone(), plan)))
                     })
                     .flatten()
             })
@@ -241,9 +244,10 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                     log::trace!("error rewriting: {e}");
                     None
                 }
-                Ok(plan) => Some(plan),
+                Ok(entry) => Some(entry),
             })
             .collect::<Vec<_>>();
+        candidates.sort_by_key(|(table_ref, _)| table_ref.to_string());
 
         if candidates.is_empty() {
             log::trace!("no candidates");
@@ -252,7 +256,12 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             Ok(Transformed::new(
                 LogicalPlan::Extension(Extension {
                     node: Arc::new(OneOf {
-                        branches: Some(node).into_iter().chain(candidates).collect_vec(),
+                        // The base plan is pinned at `branches[0]`; see
+                        // `OneOf::inputs` for why this position is load-bearing.
+                        branches: Some(node)
+                            .into_iter()
+                            .chain(candidates.into_iter().map(|(_, plan)| plan))
+                            .collect_vec(),
                     }),
                 }),
                 true,
@@ -351,10 +360,19 @@ impl UserDefinedLogicalNodeCore for OneOf {
     }
 
     fn inputs(&self) -> Vec<&LogicalPlan> {
-        self.branches
-            .iter()
-            .sorted_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-            .collect_vec()
+        // Return branches in stored order. Determinism is supplied at
+        // construction time, which sorts MV candidates by table reference and
+        // pins the base plan at `branches[0]`.
+        //
+        // The previous implementation re-sorted on every call using
+        // `LogicalPlan::partial_cmp`, which flipped the order whenever an
+        // optimizer pass changed a branch's plan shape (identity projection
+        // elimination, always-true filter folding, etc.). Since
+        // `with_exprs_and_inputs` rebuilds `branches` from this method's
+        // output, any re-sort could move the base branch off `branches[0]`,
+        // at which point `OneOf::schema()` exposes a candidate's schema
+        // instead of the original query's.
+        self.branches.iter().collect_vec()
     }
 
     fn schema(&self) -> &datafusion_common::DFSchemaRef {
@@ -578,5 +596,76 @@ impl PhysicalOptimizerRule for PruneCandidates {
 
     fn schema_check(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion_expr::LogicalPlanBuilder;
+
+    #[test]
+    fn one_of_inputs_returns_stored_order_without_resort() {
+        // Regression test: `OneOf::inputs()` used to re-sort by
+        // `LogicalPlan::partial_cmp`, which flipped branch order whenever a
+        // downstream optimizer pass mutated a branch (identity Projection
+        // elimination, always-true Filter folding, etc.). `inputs()` must
+        // return the stored order verbatim so the base branch stays at
+        // index 0 across `with_exprs_and_inputs` rebuilds.
+        let base = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let candidate = LogicalPlanBuilder::empty(true)
+            .build()
+            .expect("candidate plan");
+        // Deliberately store an order that `partial_cmp` would permute: if
+        // `inputs()` re-sorted, `base` would no longer be at index 0.
+        let one_of = OneOf {
+            branches: vec![base.clone(), candidate.clone()],
+        };
+
+        let exposed = UserDefinedLogicalNodeCore::inputs(&one_of);
+        assert_eq!(exposed.len(), 2);
+        assert_eq!(*exposed[0], base, "index 0 must remain the base branch");
+        assert_eq!(*exposed[1], candidate);
+    }
+
+    #[test]
+    fn one_of_schema_survives_with_exprs_and_inputs_rebuild() {
+        // `OneOf::schema()` reads `branches[0].schema()`, and DataFusion's
+        // tree rewrites rebuild the node from `inputs()` output via
+        // `with_exprs_and_inputs`. If `inputs()` re-sorted and moved a
+        // candidate to index 0, the rebuilt `OneOf` would expose the
+        // candidate's schema (possibly different nullability or column
+        // qualification) instead of the original query's.
+        let base_nonnull = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let candidate_nullable = LogicalPlanBuilder::empty(true)
+            .build()
+            .expect("nullable candidate plan");
+
+        let one_of = OneOf {
+            branches: vec![base_nonnull.clone(), candidate_nullable.clone()],
+        };
+        assert_eq!(
+            UserDefinedLogicalNodeCore::schema(&one_of),
+            base_nonnull.schema()
+        );
+
+        let rebuilt = UserDefinedLogicalNodeCore::with_exprs_and_inputs(
+            &one_of,
+            vec![],
+            UserDefinedLogicalNodeCore::inputs(&one_of)
+                .into_iter()
+                .cloned()
+                .collect(),
+        )
+        .expect("rebuild OneOf");
+        assert_eq!(
+            UserDefinedLogicalNodeCore::schema(&rebuilt),
+            base_nonnull.schema(),
+            "rebuild must not move the base branch off index 0"
+        );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A (found while building on top of the view-matching machinery downstream).

## Rationale for this change

`OneOf::inputs()` re-sorts its branches on every call using `LogicalPlan::partial_cmp`:

```rust
fn inputs(&self) -> Vec<&LogicalPlan> {
    self.branches
        .iter()
        .sorted_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
        .collect_vec()
}
```

This has two problems:

1. **`OneOf::schema()` can expose the wrong schema.** `schema()` reads `branches[0].schema()`, and DataFusion tree rewrites rebuild the node from `inputs()` output via `with_exprs_and_inputs`. Whenever an optimizer pass mutates one branch's plan shape (identity projection elimination, always-true filter folding, etc.), the `partial_cmp` outcome can change, a candidate can sort before the base plan, and after the rebuild the parent `OneOf` reports the candidate's schema (which may differ in nullability or column qualification) instead of the original query's.
2. **Branch order is nondeterministic across processes.** Candidates are generated by iterating the `mv_plans` `HashMap`, so two identical processes can build the same `OneOf` with different branch orders. Cost ties in `PruneCandidates` resolve to the first minimum, so the selected candidate for exactly-tied costs is not reproducible.

## What changes are included in this PR?

- `OneOf::inputs()` returns the stored branch order verbatim.
- Determinism moves to construction time: candidate rewrites are sorted by table reference, and the base plan is pinned at `branches[0]`.
- Two regression tests: the stored-order contract, and schema stability across a `with_exprs_and_inputs` rebuild.

## Are these changes tested?

Yes, two new unit tests; the existing suite passes unchanged.

## Are there any user-facing changes?

Plan selection between exactly-tied candidates becomes deterministic (first by base, then by candidate table reference). No API changes.
